### PR TITLE
[Chrome Extension] Quick fix: import typo in index.tsx

### DIFF
--- a/extension/src/ts/index.tsx
+++ b/extension/src/ts/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
-import Popup from './Popup';
+import Popup from './popup';
 
 const root: Root = createRoot(
     document.getElementById("react-target") as HTMLElement


### PR DESCRIPTION
Quick fix in index.tsx: `import Popup from './Popup';` -> `import Popup from './popup';`

Error message on `npm run dev`:
```
WARNING in ./src/ts/Popup.tsx
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Use equal casing. Compare these module identifiers:
* /Users/sung/Workshop/chk/yubaba/extension/node_modules/ts-loader/index.js!/Users/sung/Workshop/chk/yubaba/extension/src/ts/Popup.tsx
    Used by 1 module(s), i. e.
    /Users/sung/Workshop/chk/yubaba/extension/node_modules/ts-loader/index.js!/Users/sung/Workshop/chk/yubaba/extension/src/ts/index.tsx
* /Users/sung/Workshop/chk/yubaba/extension/node_modules/ts-loader/index.js!/Users/sung/Workshop/chk/yubaba/extension/src/ts/popup.tsx
 @ ./src/ts/index.tsx 3:0-28 6:24-29
```