### PR TITLE
Update chrome extension to make api calls to AWS Lambda using current URL

### DIFF
--- a/aws/lambda/lambda_function.py
+++ b/aws/lambda/lambda_function.py
@@ -28,22 +28,22 @@ def handler(event, context):
     logging.debug(f"Article date: {article.publish_date}")
     logging.debug(f"Article authors: {article.authors}")
     
-    # Set up inference payload that contains article body
-    inference_payload = {
-        "inputs": [article.text]
-    }
-    
     # Send error response if the given URL does not contain a valid article
     # https://github.com/codelucas/newspaper/blob/master/newspaper/article.py#L322
     if not article.is_valid_body():
         return {
             "statusCode": 202,
             'headers': {'Content-Type': 'application/json'},
-            "body": json.dumps([{
-                "url": url
-            }])
+            "body": json.dumps({
+                "message": "There are not enough texts on this page to generate summary!"
+            })
         }
     
+    # Set up inference payload that contains article body
+    inference_payload = {
+        "inputs": [article.text]
+    }
+
     # Invoke an inference endpoint
     # Response example: [{'summary_text': 'This is an example of article summary.'}]
     response = runtime.invoke_endpoint(EndpointName=ENDPOINT_NAME,

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -17,9 +17,9 @@ function Popup() {
     const [articleTitle, setArticleTitle] = useState('');
 
     useEffect(() => {
-        chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
+        chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([tab]) => {
             const request: MLISRequest = {
-                url: tabs[0].url,
+                url: tab.url,
             };
             chrome.runtime.sendMessage(request, (response: MLISResponse) => {
                 if (response && response.articleSummary) {

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -30,6 +30,7 @@ function Popup() {
                     }
                     else if (response.status == 202) {
                         setContent(response.message!);
+                        setIsLoading(false);
                     }
                 });
             });

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -3,20 +3,13 @@ import {
     AppBar,
     Card,
     CardContent,
-    CardHeader,
     CircularProgress,
     CssBaseline,
-    Link,
     Toolbar,
     Typography
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
-import wretch from 'wretch';
-import { PopupToBackgroundMsg, BackgroundToPopupMsg, MsgType, MLISResponse } from "../extension/types";
-
-// TODO: Issue #14: Change url and endpoint after MLIS is ready
-const apiRoot: string = "http://localhost:8000";
-const summarizationEndpoint: string = "/summary";
+import { MLISRequest, MLISResponse } from "../extension/types";
 
 function Popup() {
     const [isLoading, setIsLoading] = useState(true);
@@ -24,19 +17,14 @@ function Popup() {
     const [articleTitle, setArticleTitle] = useState('');
 
     useEffect(() => {
-        const msg: PopupToBackgroundMsg = {
-            type: MsgType.PopUpInit
+        const request: MLISRequest = {
+            url: window.location.href,
         };
-        chrome.runtime.sendMessage(msg, (response: BackgroundToPopupMsg) => {
-            if (response && response.textToSummarize) {
-                wretch(apiRoot + summarizationEndpoint)
-                    .options({ mode: "cors" })
-                    .post({ text: response.textToSummarize })
-                    .json((mlisResponse: MLISResponse) => {
-                        setArticleTitle(response.articleTitle);
-                        setContent(mlisResponse.text);
-                        setIsLoading(false);
-                    });
+        chrome.runtime.sendMessage(request, (response: MLISResponse) => {
+            if (response && response.articleSummary) {
+                setArticleTitle(response.articleTitle);
+                setContent(response.articleSummary);
+                setIsLoading(false);
             }
         });
     }, []);

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -22,10 +22,13 @@ function Popup() {
                 url: tab.url,
             };
             chrome.runtime.sendMessage(request, (response: MLISResponse) => {
-                if (response && response.articleSummary) {
-                    setArticleTitle(response.articleTitle);
-                    setContent(response.articleSummary);
+                if (response.status == 200 && response.articleSummary) {
+                    setArticleTitle(response.articleTitle!);
+                    setContent(response.articleSummary!);
                     setIsLoading(false);
+                }
+                else if (response.status == 202) {
+                    setContent(response.message!);
                 }
             });
         });

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -17,19 +17,21 @@ function Popup() {
     const [articleTitle, setArticleTitle] = useState('');
 
     useEffect(() => {
-        chrome.tabs.query({ active: true, lastFocusedWindow: true }, ([tab]) => {
-            const request: MLISRequest = {
-                url: tab.url,
-            };
-            chrome.runtime.sendMessage(request, (response: MLISResponse) => {
-                if (response.status == 200 && response.articleSummary) {
-                    setArticleTitle(response.articleTitle!);
-                    setContent(response.articleSummary!);
-                    setIsLoading(false);
-                }
-                else if (response.status == 202) {
-                    setContent(response.message!);
-                }
+        chrome.windows.getCurrent(w => {
+            chrome.tabs.query({ active: true, windowId: w.id }, ([tab]) => {
+                const request: MLISRequest = {
+                    url: tab.url,
+                };
+                chrome.runtime.sendMessage(request, (response: MLISResponse) => {
+                    if (response.status == 200 && response.articleSummary) {
+                        setArticleTitle(response.articleTitle!);
+                        setContent(response.articleSummary!);
+                        setIsLoading(false);
+                    }
+                    else if (response.status == 202) {
+                        setContent(response.message!);
+                    }
+                });
             });
         });
     }, []);

--- a/extension/src/components/Popup.tsx
+++ b/extension/src/components/Popup.tsx
@@ -17,15 +17,17 @@ function Popup() {
     const [articleTitle, setArticleTitle] = useState('');
 
     useEffect(() => {
-        const request: MLISRequest = {
-            url: window.location.href,
-        };
-        chrome.runtime.sendMessage(request, (response: MLISResponse) => {
-            if (response && response.articleSummary) {
-                setArticleTitle(response.articleTitle);
-                setContent(response.articleSummary);
-                setIsLoading(false);
-            }
+        chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => {
+            const request: MLISRequest = {
+                url: tabs[0].url,
+            };
+            chrome.runtime.sendMessage(request, (response: MLISResponse) => {
+                if (response && response.articleSummary) {
+                    setArticleTitle(response.articleTitle);
+                    setContent(response.articleSummary);
+                    setIsLoading(false);
+                }
+            });
         });
     }, []);
 

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -2,17 +2,20 @@ import wretch from 'wretch';
 import { MLISRequest, MLISResponse } from './types';
 
 // TODO: Issue #14: Change url and endpoint after MLIS is ready
-const apiRoot: string = "http://localhost:8000";
+// const apiRoot: string = "http://localhost:8000";
+const apiRoot: string = "https://jlgl3bu3n6.execute-api.us-east-1.amazonaws.com/test/pass-article-to-summarization-model";
 const summarizationEndpoint: string = "/summary";
 
-
+console.log("background")
 try {
     chrome.runtime.onMessage.addListener(
         function (request: MLISRequest, _, sendResponse: (response: MLISResponse) => void) {
+            console.log("Message received")
             wretch(apiRoot + summarizationEndpoint)
                 .options({ mode: "cors" })
                 .post({ text: request.url })
                 .json((mlisResponse: MLISResponse) => {
+                    console.log(mlisResponse)
                     sendResponse(mlisResponse)
                 });
         }

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -4,11 +4,10 @@ import { MLISRequest, MLISResponse } from './types';
 const apiRoot: string = "https://aacxuouv1m.execute-api.us-east-1.amazonaws.com/default";
 const summarizationEndpoint: string = "/summarize";
 
-console.log("background")
 try {
     chrome.runtime.onMessage.addListener(
         function (request: MLISRequest, _, sendResponse: (response: MLISResponse) => void) {
-            console.log("Message received")
+            console.log("[Yubaba] Waiting for summarization process...")
             wretch(apiRoot + summarizationEndpoint)
                 .options({ mode: "cors" })
                 .post({ url: request.url })

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -1,24 +1,20 @@
 import wretch from 'wretch';
-import { MsgType } from './types';
+import { MLISRequest, MLISResponse } from './types';
 
+// TODO: Issue #14: Change url and endpoint after MLIS is ready
+const apiRoot: string = "http://localhost:8000";
+const summarizationEndpoint: string = "/summary";
 
-var textToSummarize: string | null;
 
 try {
     chrome.runtime.onMessage.addListener(
-        function (request, _, sendResponse) {
-            if (request.type === MsgType.PageContent) {
-                textToSummarize = request.text;
-            }
-            else if (request.type === MsgType.PopUpInit) {
-                if (textToSummarize != null) {
-                    sendResponse({
-                        textToSummarize: textToSummarize,
-                        // TODO: read article title from contentScript.ts & replace placeholder title
-                        articleTitle: "'Article Title Placeholder'"
-                    });
-                }
-            }
+        function (request: MLISRequest, _, sendResponse: (response: MLISResponse) => void) {
+            wretch(apiRoot + summarizationEndpoint)
+                .options({ mode: "cors" })
+                .post({ text: request.url })
+                .json((mlisResponse: MLISResponse) => {
+                    sendResponse(mlisResponse)
+                });
         }
     );
 } catch (err) {

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -6,15 +6,25 @@ const summarizationEndpoint: string = "/summarize";
 
 try {
     chrome.runtime.onMessage.addListener(
-        function (request: MLISRequest, _, sendResponse: (response: MLISResponse) => void) {
+        function (
+            request: MLISRequest,
+            _,
+            sendResponse: (response: MLISResponse) => void
+        ) {
             console.log("[Yubaba] Waiting for summarization process...")
             wretch(apiRoot + summarizationEndpoint)
                 .options({ mode: "cors" })
                 .post({ url: request.url })
-                .json((mlisResponse: MLISResponse) => {
-                    console.log(mlisResponse)
-                    sendResponse(mlisResponse)
-                });
+                .res(res => {
+                    res.json().then(body => {
+                        console.log(`[Yubaba] (${res.status}) Received response:`)
+                        console.log(body)
+                        sendResponse({
+                            ...body,
+                            status: res.status,
+                        })
+                    })
+                })
         }
     );
 } catch (err) {

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -20,14 +20,14 @@ try {
                 })
                 .res(res => {
                     res.json().then(body => {
-                        console.log(`[Yubaba] (${res.status}) Received response:`)
-                        console.log(body)
+                        console.log(`[Yubaba] (${res.status}) Received response:`, body)
                         sendResponse({
                             ...body,
                             status: res.status,
                         })
                     })
                 })
+            return true; // This allows message sender to wait for async sendResponse
         }
     );
 } catch (err) {

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -3,7 +3,7 @@ import { MLISRequest, MLISResponse } from './types';
 
 // TODO: Issue #14: Change url and endpoint after MLIS is ready
 // const apiRoot: string = "http://localhost:8000";
-const apiRoot: string = "https://jlgl3bu3n6.execute-api.us-east-1.amazonaws.com/test/pass-article-to-summarization-model";
+const apiRoot: string = "https://jlgl3bu3n6.execute-api.us-east-1.amazonaws.com/test/pass-article-to-summarization-model/";
 const summarizationEndpoint: string = "/summary";
 
 console.log("background")

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -15,6 +15,9 @@ try {
             wretch(apiRoot + summarizationEndpoint)
                 .options({ mode: "cors" })
                 .post({ url: request.url })
+                .error(500, error => {
+                    // TODO: Implement error page (https://github.com/TeamCHK/yubaba/issues/24)
+                })
                 .res(res => {
                     res.json().then(body => {
                         console.log(`[Yubaba] (${res.status}) Received response:`)

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -1,8 +1,6 @@
 import wretch from 'wretch';
 import { MLISRequest, MLISResponse } from './types';
 
-// TODO: Issue #14: Change url and endpoint after MLIS is ready
-// const apiRoot: string = "http://localhost:8000";
 const apiRoot: string = "https://aacxuouv1m.execute-api.us-east-1.amazonaws.com/default";
 const summarizationEndpoint: string = "/summarize";
 

--- a/extension/src/extension/background.ts
+++ b/extension/src/extension/background.ts
@@ -3,8 +3,8 @@ import { MLISRequest, MLISResponse } from './types';
 
 // TODO: Issue #14: Change url and endpoint after MLIS is ready
 // const apiRoot: string = "http://localhost:8000";
-const apiRoot: string = "https://jlgl3bu3n6.execute-api.us-east-1.amazonaws.com/test/pass-article-to-summarization-model/";
-const summarizationEndpoint: string = "/summary";
+const apiRoot: string = "https://aacxuouv1m.execute-api.us-east-1.amazonaws.com/default";
+const summarizationEndpoint: string = "/summarize";
 
 console.log("background")
 try {
@@ -13,7 +13,7 @@ try {
             console.log("Message received")
             wretch(apiRoot + summarizationEndpoint)
                 .options({ mode: "cors" })
-                .post({ text: request.url })
+                .post({ url: request.url })
                 .json((mlisResponse: MLISResponse) => {
                     console.log(mlisResponse)
                     sendResponse(mlisResponse)

--- a/extension/src/extension/contentScript.ts
+++ b/extension/src/extension/contentScript.ts
@@ -1,16 +1,1 @@
-import { ContentToBackgroundMsg, MsgType } from "./types";
-
-const sendContent = (textToSend: string) => {
-    const msg: ContentToBackgroundMsg = {
-        type: MsgType.PageContent,
-        text: textToSend
-    };
-    chrome.runtime.sendMessage(msg);
-};
-//TODO: Decide and change whether we'll serve all types of websites vs only certain websites
-if (window.location.href.includes('cnn.com') && window.location.href.includes('index.html')) {
-    const body: HTMLElement = document.body;
-    const bodyText: Array<string> = body.outerText.split("\n").filter(text => text);
-
-    sendContent(bodyText[15]);
-}
+// TODO: Inject summary or other UI components in certain popular websites (Medium, CNN, Wall Street Journal, etc.)

--- a/extension/src/extension/types.ts
+++ b/extension/src/extension/types.ts
@@ -3,8 +3,10 @@ export type MLISRequest = {
 }
 
 export type MLISResponse = {
-    articleSummary: string,
+    status: number,
+    message?: string,
+    articleSummary?: string,
     articleTitle?: string,
     articleAuthors?: string[],
     publishDate?: Date,
-};
+}

--- a/extension/src/extension/types.ts
+++ b/extension/src/extension/types.ts
@@ -1,22 +1,10 @@
-export enum MsgType {
-    PageContent = 'page-content',
-    PopUpInit = 'popup-init',
-};
-
-export type ContentToBackgroundMsg = {
-    type: MsgType,
-    text: string
-};
-
-export type PopupToBackgroundMsg = {
-    type: MsgType
-};
-
-export type BackgroundToPopupMsg = {
-    articleTitle: string,
-    textToSummarize: string
-};
+export type MLISRequest = {
+    url: string,
+}
 
 export type MLISResponse = {
-    text: string
+    articleSummary: string,
+    articleTitle?: string,
+    articleAuthors?: string[],
+    publishDate?: Date,
 };

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -3,7 +3,7 @@ const glob = require('glob');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 
-const matchedFiles = glob.sync(`./src/extension/*(*.tsx|*.ts)`, {
+const matchedFiles = glob.sync(`./src/**(extension|components)/*(*.tsx|*.ts)`, {
     nodir: true
 });
 
@@ -11,15 +11,17 @@ const entry = {}
 
 matchedFiles.forEach(file => {
     const TS_FOLDER = path.join(__dirname, 'src/extension');
+    const TSX_FOLDER = path.join(__dirname, 'src/components');
     const ABS_PATH = path.join(__dirname, file);
 
-    const relativeFile = path.relative(TS_FOLDER, ABS_PATH);
+    const relativeTSFile = path.relative(TS_FOLDER, ABS_PATH);
+    const relativeTSXFile = path.relative(TSX_FOLDER, ABS_PATH);
 
     var fileKey;
-    if (relativeFile.includes('.tsx')) {
-        fileKey = path.join(path.dirname(relativeFile), path.basename(relativeFile, '.tsx'));
-    } else if (relativeFile.includes('.ts')) {
-        fileKey = path.join(path.dirname(relativeFile), path.basename(relativeFile, '.ts'));
+    if (relativeTSXFile.includes('.tsx')) {
+        fileKey = path.join(path.dirname(relativeTSXFile), path.basename(relativeTSXFile, '.tsx'));
+    } else if (relativeTSFile.includes('.ts')) {
+        fileKey = path.join(path.dirname(relativeTSFile), path.basename(relativeTSFile, '.ts'));
     }
     if (fileKey != null) {
         entry[fileKey] = file;


### PR DESCRIPTION
- Make API calls in background script instead of popup script
  - Currently triggered by popup script only, but can later be triggered by content script as well (HTML Injection)
  - Make calls to AWS API instead of localhost
- Update popup script to send a URL to background script
- Remove code from content script
- Update corresponding types in `types.ts`

Updates:
- Send failure message instead of url for invalid articles in `lambda_function.py`
- Handle successful responses differently depending on status code in `Popup.tsx`
- Use `wretch().res()` instead of `wretch().json()` in order to access the response code
- Add empty `wretch().error()` for TODO PR
- Fix loading wheel error by returning true at the end of message listener (it indicates there will be an asynchronous response)