### PR TITLE
Validate url by using newspaper3k's is_valid_url()

### DIFF
--- a/aws/lambda/lambda_function.py
+++ b/aws/lambda/lambda_function.py
@@ -9,6 +9,8 @@ logging.root.setLevel(logging.DEBUG)
 ENDPOINT_NAME = os.environ['ENDPOINT_NAME']
 runtime = boto3.client('runtime.sagemaker')
 
+ARTICLE_LENGTH_MINIMUM = 100
+
 def handler(event, context):
     # Extract URL from the request
     # Request example: {"headers": {}, "httpMethod": "POST", "body": "{\"url\":\"https://example.com\"}"}
@@ -30,7 +32,7 @@ def handler(event, context):
     
     # Send error response if the given URL does not contain a valid article
     # https://github.com/codelucas/newspaper/blob/master/newspaper/urls.py#L102
-    if not article.is_valid_url():
+    if not article.is_valid_body() and not article.is_valid_url() and len(article.text) < ARTICLE_LENGTH_MINIMUM:
         return {
             "statusCode": 202,
             'headers': {'Content-Type': 'application/json'},

--- a/aws/lambda/lambda_function.py
+++ b/aws/lambda/lambda_function.py
@@ -29,8 +29,8 @@ def handler(event, context):
     logging.debug(f"Article authors: {article.authors}")
     
     # Send error response if the given URL does not contain a valid article
-    # https://github.com/codelucas/newspaper/blob/master/newspaper/article.py#L322
-    if not article.is_valid_body():
+    # https://github.com/codelucas/newspaper/blob/master/newspaper/urls.py#L102
+    if not article.is_valid_url():
         return {
             "statusCode": 202,
             'headers': {'Content-Type': 'application/json'},


### PR DESCRIPTION
newspaper3k's `is_valid_body()` is too strict to validate most URLs.
Even CNN articles fail to pass the [function](https://github.com/codelucas/newspaper/blob/master/newspaper/article.py#L322).

Along with `is_valid_body()`, we should also use `is_valid_url()` which has the main logic [here](https://github.com/codelucas/newspaper/blob/master/newspaper/urls.py#L102).

It has a fairly reasonable article validation process which includes:
- Basic URL regex check
- Check if a web page contains a date
- Look for certain keywords (e.g. story, article, news, press, etc.)

To make it less strict, we now check both `is_valid_body()` and `is_valid_url()` and also the length of the body text.